### PR TITLE
Add dynamic menu items

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -249,8 +249,8 @@ window_title = "Open a File"
 resizable = true
 mode = 0
 access = 2
-current_dir = "/home/raptor/program/godot/signum/Signum"
-current_path = "/home/raptor/program/godot/signum/Signum/"
+current_dir = "C:/Users/Slooth/Documents/GitHub/Signum-Fork"
+current_path = "C:/Users/Slooth/Documents/GitHub/Signum-Fork/"
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -267,8 +267,8 @@ margin_bottom = 204.416
 popup_exclusive = true
 resizable = true
 access = 2
-current_dir = "/home/raptor/program/godot/signum/Signum"
-current_path = "/home/raptor/program/godot/signum/Signum/"
+current_dir = "C:/Users/Slooth/Documents/GitHub/Signum-Fork"
+current_path = "C:/Users/Slooth/Documents/GitHub/Signum-Fork/"
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -296,7 +296,6 @@ margin_right = 83.0
 margin_bottom = 37.0
 custom_fonts/font = ExtResource( 2 )
 text = "File"
-items = [ "Open File", null, 0, false, false, 0, 0, null, "", false, "Save As File", null, 0, false, false, 1, 0, null, "", false, "Save File", null, 0, false, false, 4, 0, null, "", false, "New File", null, 0, false, false, 3, 0, null, "", false, "Quit", null, 0, false, false, 2, 0, null, "", false ]
 switch_on_hover = true
 __meta__ = {
 "_edit_use_anchors_": false
@@ -308,7 +307,6 @@ margin_right = 146.0
 margin_bottom = 37.0
 custom_fonts/font = ExtResource( 2 )
 text = "Help"
-items = [ "About", null, 0, false, false, 0, 0, null, "", false, "Github", null, 0, false, false, 1, 0, null, "", false, "Report a Bug", null, 0, false, false, 2, 0, null, "", false ]
 switch_on_hover = true
 __meta__ = {
 "_edit_use_anchors_": false

--- a/Scripts/Main.gd
+++ b/Scripts/Main.gd
@@ -6,6 +6,7 @@ onready var save_as_file_dialog = get_node('SaveAsFileDialog')
 onready var open_file_dialog = get_node('OpenFileDialog')
 onready var about_popup = get_node('AboutPopup')
 onready var tab_container = get_node("HSplitContainer/TabContainer")
+onready var menu = get_node('Menu')
 
 #Reference to current working tab
 var current_tab = null
@@ -25,7 +26,9 @@ func _ready():
 	else:
 		#Create new file
 		new_file()
-
+	
+	menu.set_callback_target(self)
+	menu.initialize()
 
 
 #Get file name from File path
@@ -39,50 +42,7 @@ func get_file_name(file : String):
 func title_update():
 	# This sets the title for the current title
 	OS.set_window_title('Signum - ' + current_file)
-	
 
-
-# File Menu IDs:
-# Open File = 0
-# Save As File = 1
-# Save File = 4
-# Quit = 2
-# New File = 3
-# ----------------
-# Help Menu IDs:
-# About = 0
-# Github Page = 1
-# Github Issues = 2
-
-func file_item_pressed(id):
-	match id:
-		0:
-			# Opens file select dialog
-			open_file_dialog.popup()
-		1:
-			# Opens save file dialog
-			save_as_file_dialog.popup()
-		2:
-			# Closes the program
-			get_tree().quit()
-		3:
-			# Creates file
-			new_file()
-		4:
-			# Saves file without changing the name
-			save_file()
-
-func help_item_pressed(id):
-	match id:
-		0:
-			# Opens about popup
-			about_popup.popup()
-		1:
-			# Opens the github page in the browser
-			OS.shell_open('https://github.com/MintStudios/Signum')
-		2:
-			# Opens issues in github
-			OS.shell_open('https://github.com/MintStudios/Signum/issues')
 
 # Creates a new file
 func new_file():
@@ -91,6 +51,37 @@ func new_file():
 	title_update()
 	# Resets the text back to nothing
 	current_tab.get_node("TextEdit").text = ''
+
+
+# Open File menu item callback
+func open_file_pressed():
+	open_file_dialog.popup()
+
+
+# Save As File menu item callback
+func save_as_file_pressed():
+	save_as_file_dialog.popup()
+
+
+# Quit menu item callback
+func quit_pressed():
+	get_tree().quit()
+
+
+# About menu item callback
+func about_pressed():
+	about_popup.popup()
+
+
+# GitHub menu item callback
+func github_pressed():
+	OS.shell_open("https://github.com/MintStudios/Signum")
+
+
+# Report a Bug menu item callback
+func report_bug_pressed():
+	OS.shell_open("https://github.com/MintStudios/Signum/issues")
+
 
 # Opens an existing file
 func open_file_selected(path):

--- a/Scripts/Menu.gd
+++ b/Scripts/Menu.gd
@@ -3,31 +3,60 @@ extends HBoxContainer
 onready var file_menu = get_node('FileMenu')
 onready var help_menu = get_node('HelpMenu')
 
-# File Menu IDs:
-# Open File = 0
-# Save As File = 1
-# Save File = 4
-# Quit = 2
-# New File = 3
-# ----------------
-# Help Menu IDs:
-# About = 0
-# Github Page = 1
+var callback_target = null
 
-func _ready():
-	# Sets all the shortcuts
-	file_menu.get_popup().set_item_shortcut(0, set_shortcut(KEY_O), true)
-	file_menu.get_popup().set_item_shortcut(1, set_shortcut(KEY_E), true)
-	file_menu.get_popup().set_item_shortcut(4, set_shortcut(KEY_Q), true)
-	file_menu.get_popup().set_item_shortcut(2, set_shortcut(KEY_S), true)
-	file_menu.get_popup().set_item_shortcut(3, set_shortcut(KEY_N), true)
-	
-	# Connects the signals of the items to the main script
-	file_menu.get_popup().connect('id_pressed', get_parent(), 'file_item_pressed')
-	help_menu.get_popup().connect('id_pressed', get_parent(), 'help_item_pressed')
+var file_menu_items = [
+	{
+		"text": "Open File",
+		"callback": "open_file_pressed",
+		"shortcut_key": KEY_O
+	},
+	{
+		"text": "Save As File",
+		"callback": "save_as_file_pressed",
+		"shortcut_key": KEY_E
+	},
+	{
+		"text": "Save File",
+		"callback": "save_file",
+		"shortcut_key": KEY_S
+	},
+	{
+		"text": "New File",
+		"callback": "new_file",
+		"shortcut_key": KEY_N
+	},
+	{
+		"text": "Quit",
+		"callback": "quit_pressed",
+		"shortcut_key": KEY_Q
+	}
+]
+
+var help_menu_items = [
+	{
+		"text": "About",
+		"callback": "about_pressed",
+		"shortcut_key": null
+	},
+	{
+		"text": "GitHub",
+		"callback": "github_pressed",
+		"shortcut_key": null
+	},
+	{
+		"text": "Report a Bug",
+		"callback": "report_bug_pressed",
+		"shortcut_key": null
+	}
+]
+
+func initialize():
+	populate_menu()
+
 
 # Function that makes a shortcut
-func set_shortcut(key):
+func create_shortcut(key):
 	# Creates ShortCut and InputKeyEvent
 	var shortcut = ShortCut.new()
 	var inputeventkey = InputEventKey.new()
@@ -37,3 +66,70 @@ func set_shortcut(key):
 	# Makes the final shortcut and returns it
 	shortcut.set_shortcut(inputeventkey)
 	return shortcut
+
+
+func populate_menu():
+	add_menu_items(file_menu, file_menu_items, self, "file_item_pressed")
+	add_menu_items(help_menu, help_menu_items, self, "help_item_pressed")
+
+
+func add_menu_items(menu, items, target, callback):
+	# Local index to track as we iterate over the items
+	var _index = 0
+	
+	for item in items:
+		menu.get_popup().add_item(item.get("text"))
+		# If the menu item has a shortcut key, assign it
+		if (item.get("shortcut_key")):
+			menu.get_popup().set_item_shortcut(
+				# Index of the item we're setting the shortcut for
+				_index,
+				# The Shortcut object
+				create_shortcut(item.get("shortcut_key")),
+				# Specify that the shortcut is global
+				true
+			)
+	
+		# We haven't found the item yet, keep iterating
+		_index += 1
+	
+	# Connect the signal for when an item is pressed
+	menu.get_popup().connect("id_pressed", target, callback)
+
+
+func call_menu_item_callback(index, items):
+	# Attempt to find the item at the index pressed in the menu popup
+	var item = find_menu_item_at_index(index, items)
+	
+	# If we've found an item, call the item's callback
+	if (item != null and callback_target != null):
+		callback_target.call(item.get("callback"))
+
+
+func find_menu_item_at_index(index, items):
+	# Local index to track as we iterate over the items
+	var _index = 0
+	
+	for item in items:
+		# If the pressed index matches our iteration index, we've
+		# found the item
+		if (_index == index):
+			return item
+		# We haven't found the item yet, keep iterating
+		_index += 1
+	
+	# We didn't find the item for some reason, return null
+	return null
+
+
+# Set the callback target for menu item callbacks
+func set_callback_target(target):
+	callback_target = target
+
+
+func file_item_pressed(id):
+	call_menu_item_callback(id, file_menu_items)
+
+
+func help_item_pressed(id):
+	call_menu_item_callback(id, help_menu_items)


### PR DESCRIPTION
**Describe everything your commit(s) does:**
Adds dynamic menu item declarations in `Menu.gd`, enabling quicker and easier creation/deletion of menu items.


**Describe how this would make Signum have a better experience:**
This allows for easier creation of menu items for developers, and removes the inconvenience and clutter of hardcoded matching for menu item ids by making it dynamic.


**Describe the code; What does each piece of code do?:**
This adds new variables containing menu item information for the `File` and `Help` menus. Each item should contain the `text` to be displayed, a `callback`, and an optional `shortcut_key`. The items are loaded when the menu is initialized (from `Main.gd`). A `callback_target` variable was added in `Menu.gd`, specifying the class that the menu item callbacks should be called on.