### PR TITLE
Tab close and tab drag rearrange feature (Important)

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -228,12 +228,25 @@ enabled_focus_mode = 0
 text = "Default"
 script = ExtResource( 9 )
 
-[node name="TabContainer" type="TabContainer" parent="HSplitContainer"]
+[node name="Editor" type="Control" parent="HSplitContainer"]
 margin_left = 258.0
 margin_right = 1004.0
 margin_bottom = 548.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="TabContainer" type="Tabs" parent="HSplitContainer/Editor"]
+anchor_right = 1.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 0, 24 )
+size_flags_horizontal = 3
 tab_align = 0
+tab_close_display_policy = 2
 drag_to_rearrange_enabled = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="OpenFileDialog" type="FileDialog" parent="."]
 anchor_left = 0.5
@@ -356,6 +369,8 @@ texture = ExtResource( 8 )
 [connection signal="toggled" from="HSplitContainer/Sidebar/Settings/ShowLineNumbers/CheckButton" to="HSplitContainer/Sidebar/Settings" method="show_line_numbers_toggled"]
 [connection signal="toggled" from="HSplitContainer/Sidebar/Settings/Caret/CheckButton" to="HSplitContainer/Sidebar/Settings" method="caret_toggled"]
 [connection signal="item_selected" from="HSplitContainer/Sidebar/Settings/Theme/ThemeButton" to="HSplitContainer/Sidebar/Settings/Theme/ThemeButton" method="theme_select"]
-[connection signal="tab_changed" from="HSplitContainer/TabContainer" to="." method="_on_TabContainer_tab_changed"]
+[connection signal="reposition_active_tab_request" from="HSplitContainer/Editor/TabContainer" to="." method="_on_TabContainer_reposition_active_tab_request"]
+[connection signal="tab_changed" from="HSplitContainer/Editor/TabContainer" to="." method="_on_TabContainer_tab_changed"]
+[connection signal="tab_close" from="HSplitContainer/Editor/TabContainer" to="." method="_on_TabContainer_tab_close"]
 [connection signal="file_selected" from="OpenFileDialog" to="." method="open_file_selected"]
 [connection signal="file_selected" from="SaveAsFileDialog" to="." method="save_as_file_selected"]

--- a/Scenes/Tab.tscn
+++ b/Scenes/Tab.tscn
@@ -1,21 +1,16 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://Fonts/Hack-Regular.tres" type="DynamicFont" id=1]
 [ext_resource path="res://Scripts/Tab.gd" type="Script" id=2]
-[ext_resource path="res://Resources/close.png" type="Texture" id=3]
 
 [node name="Tabs" type="Tabs" groups=[
 "Tabs",
 ]]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 5.0
-margin_top = 29.0
-margin_right = -5.0
-margin_bottom = -5.0
-grow_horizontal = 2
-custom_icons/close = ExtResource( 3 )
-tab_close_display_policy = 1
+margin_top = 24.0
+size_flags_vertical = 3
+tab_align = 0
 drag_to_rearrange_enabled = true
 script = ExtResource( 2 )
 __meta__ = {
@@ -25,9 +20,7 @@ __meta__ = {
 [node name="TextEdit" type="TextEdit" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-rect_min_size = Vector2( 650, 0 )
-size_flags_horizontal = 3
-size_flags_vertical = 3
+rect_min_size = Vector2( 650, 500 )
 custom_fonts/font = ExtResource( 1 )
 highlight_current_line = true
 syntax_highlighting = true

--- a/Scripts/Tab.gd
+++ b/Scripts/Tab.gd
@@ -3,3 +3,18 @@ extends Tabs
 #Path to file
 var file_path : String = "Untitled"
 
+#NOTE : Tab does not resize automatically when resized, manual resizing is required.
+#REASON : we don't want to auto-resize `TabContainer` (Parent of this tab)
+#		  but this tab must resize when window size is changed. To fix this,
+#		  We will change size of this tab according to parent of `TabContainer`
+onready var editor = get_parent().get_parent()
+
+func _ready():
+	#Connect resize signal
+	editor.connect("resized", self, "_on_Editor_resized")
+	#initial resize
+	_on_Editor_resized()
+
+#Manual resizing of tab
+func _on_Editor_resized():
+	rect_size = Vector2(editor.rect_size.x, editor.rect_size.y - margin_top)


### PR DESCRIPTION
**Describe everything your commit(s) does:**
Tab can now be closed by pressing x button and added tab drag and rearrange feature.


**Describe how this would make Signum have a better experience:**
Earlier opened tabs can't be closed. After this update user can now close tabs by pressing x button in tab title and user can rearrange tabs by dragging tabs which will enhance signum experience. 

**Describe the code; What does each piece of code do?:**
1.)`TabContainer` is now child of new node `editor` (Editor is of type `control` , it's added to prevent resizing of `TabContainer`).
2.)`_on_TabContainer_reposition_active_tab_request(idx_to)` is called when tab is rearranged by dragging.
- It rearranges tabs

3.) `_on_TabContainer_tab_close(tab)` is called when a tab is closed
- closes current tab
